### PR TITLE
Fix Dependencies, Logging, Resteasy Provider

### DIFF
--- a/embedded-keycloak-server-custom/pom.xml
+++ b/embedded-keycloak-server-custom/pom.xml
@@ -7,7 +7,7 @@
         <groupId>com.github.thomasdarimont.keycloak</groupId>
         <artifactId>embedded-keycloak-server-spring-boot-parent</artifactId>
         <version>1.0.0.BUILD-SNAPSHOT</version>
-        <relativePath/>
+        <relativePath>../</relativePath>
     </parent>
 
     <artifactId>embedded-keycloak-server-custom</artifactId>
@@ -34,25 +34,29 @@
             <optional>true</optional>
         </dependency>
 
+        <dependency>
+            <groupId>com.github.scribejava</groupId>
+            <artifactId>scribejava-apis</artifactId>
+            <version>6.9.0</version>
+        </dependency>
+
+        <!-- DEPENDENCY OVERRIDES https://github.com/keycloak/keycloak/blob/master/pom.xml -->
+        <dependency>
+            <groupId>org.liquibase</groupId>
+            <artifactId>liquibase-core</artifactId>
+            <version>3.5.5</version>
+        </dependency>
+
+
+
     </dependencies>
 
     <build>
 
         <resources>
             <resource>
-                <filtering>true</filtering>
-                <directory>src/main/resources</directory>
-                <includes>
-                    <include>banner.txt</include>
-                </includes>
-            </resource>
-            <resource>
                 <filtering>false</filtering>
                 <directory>src/main/resources</directory>
-                <includes>
-                    <include>*.xml</include>
-                    <include>*.yml</include>
-                </includes>
             </resource>
         </resources>
 

--- a/embedded-keycloak-server-spring-boot-support/src/main/java/com/github/thomasdarimont/keycloak/embedded/EmbeddedKeycloakApplication.java
+++ b/embedded-keycloak-server-spring-boot-support/src/main/java/com/github/thomasdarimont/keycloak/embedded/EmbeddedKeycloakApplication.java
@@ -94,7 +94,7 @@ public class EmbeddedKeycloakApplication extends KeycloakApplication {
         Resource importLocation = imex.getImportLocation();
 
         if (!importLocation.exists()) {
-            LOG.info("Could not find keycloak import file %s", importLocation);
+            LOG.info("Could not find keycloak import file {}", importLocation);
             return;
         }
 
@@ -102,11 +102,11 @@ public class EmbeddedKeycloakApplication extends KeycloakApplication {
         try {
             file = importLocation.getFile();
         } catch (IOException e) {
-            LOG.error("Could not read keycloak import file %s", importLocation, e);
+            LOG.error("Could not read keycloak import file {}", importLocation, e);
             return;
         }
 
-        LOG.info("Starting Keycloak realm configuration import from location: %s", importLocation);
+        LOG.info("Starting Keycloak realm configuration import from location: {}", importLocation);
 
         KeycloakSession session = getSessionFactory().create();
 

--- a/embedded-keycloak-server-spring-boot-support/src/main/java/com/github/thomasdarimont/keycloak/embedded/support/Resteasy3Provider.java
+++ b/embedded-keycloak-server-spring-boot-support/src/main/java/com/github/thomasdarimont/keycloak/embedded/support/Resteasy3Provider.java
@@ -1,31 +1,32 @@
 package com.github.thomasdarimont.keycloak.embedded.support;
 
 import com.google.auto.service.AutoService;
-import org.jboss.resteasy.core.ResteasyContext;
+import org.jboss.resteasy.core.Dispatcher;
+import org.jboss.resteasy.spi.ResteasyProviderFactory;
 import org.keycloak.common.util.ResteasyProvider;
 
 @AutoService(ResteasyProvider.class)
-public class Resteasy4Provider implements ResteasyProvider {
+public class Resteasy3Provider implements ResteasyProvider {
 
     @Override
     public <R> R getContextData(Class<R> type) {
-        return ResteasyContext.getContextData(type);
+        return ResteasyProviderFactory.getInstance().getContextData(type);
     }
 
     @Override
     public void pushDefaultContextObject(Class type, Object instance) {
-        ResteasyContext.getContextData(org.jboss.resteasy.spi.Dispatcher.class).getDefaultContextObjects()
+        ResteasyProviderFactory.getInstance().getContextData(Dispatcher.class).getDefaultContextObjects()
                 .put(type, instance);
     }
 
     @Override
     public void pushContext(Class type, Object instance) {
-        ResteasyContext.pushContext(type, instance);
+        ResteasyProviderFactory.getInstance().pushContext(type, instance);
     }
 
     @Override
     public void clearContextData() {
-        ResteasyContext.clearContextData();
+        ResteasyProviderFactory.getInstance().clearContextData();
     }
 
 }

--- a/pom.xml
+++ b/pom.xml
@@ -25,8 +25,8 @@
         <maven.compiler.target>${java.version}</maven.compiler.target>
         <maven.compiler.release>${java.version}</maven.compiler.release>
 
-        <keycloak.version>9.0.3</keycloak.version>
-        <resteasy.version>4.5.3.Final</resteasy.version>
+        <keycloak.version>9.0.2</keycloak.version>
+        <resteasy.version>3.11.0.Final</resteasy.version>
         <infinispan.version>9.4.19.Final</infinispan.version>
         <jgroups.version>4.0.23.Final</jgroups.version>
 

--- a/pom.xml
+++ b/pom.xml
@@ -25,7 +25,7 @@
         <maven.compiler.target>${java.version}</maven.compiler.target>
         <maven.compiler.release>${java.version}</maven.compiler.release>
 
-        <keycloak.version>9.0.2</keycloak.version>
+        <keycloak.version>9.0.3</keycloak.version>
         <resteasy.version>3.11.0.Final</resteasy.version>
         <infinispan.version>9.4.19.Final</infinispan.version>
         <jgroups.version>4.0.23.Final</jgroups.version>


### PR DESCRIPTION
Some explanation:
- Keycloak uses an older version of Liquibase (3.5.5) but the parent pom does not require this specific version, so Liquibase 3.9 is used which in turn uses an incompatible changelog format
- the resources were changed so you can actually add e.g. themes to the Jar file
- Resteasy 4 is incompatible with Keycloak as well, causing ClassNotFoundExceptions e.g. on the /auth/user/info REST call