### PR TITLE
Update Keycloak to 11.0.0

### DIFF
--- a/embedded-keycloak-server-spring-boot-support/src/main/java/com/github/thomasdarimont/keycloak/embedded/EmbeddedKeycloakConfig.java
+++ b/embedded-keycloak-server-spring-boot-support/src/main/java/com/github/thomasdarimont/keycloak/embedded/EmbeddedKeycloakConfig.java
@@ -3,13 +3,13 @@ package com.github.thomasdarimont.keycloak.embedded;
 import com.github.thomasdarimont.keycloak.embedded.support.DynamicJndiContextFactoryBuilder;
 import com.github.thomasdarimont.keycloak.embedded.support.SpringBootConfigProvider;
 import com.github.thomasdarimont.keycloak.embedded.support.SpringBootPlatform;
+import com.github.thomasdarimont.keycloak.embedded.support.UndertowRequestFilter;
 import lombok.extern.slf4j.Slf4j;
 import org.infinispan.configuration.parsing.ConfigurationBuilderHolder;
 import org.infinispan.configuration.parsing.ParserRegistry;
 import org.infinispan.manager.DefaultCacheManager;
 import org.jboss.resteasy.plugins.server.servlet.HttpServlet30Dispatcher;
 import org.jboss.resteasy.plugins.server.servlet.ResteasyContextParameters;
-import org.keycloak.services.filters.KeycloakSessionServletFilter;
 import org.springframework.boot.autoconfigure.condition.ConditionalOnMissingBean;
 import org.springframework.boot.autoconfigure.web.ServerProperties;
 import org.springframework.boot.web.servlet.FilterRegistrationBean;
@@ -120,11 +120,11 @@ public class EmbeddedKeycloakConfig {
 
     @Bean
     @ConditionalOnMissingBean(name = "keycloakSessionManagement")
-    protected FilterRegistrationBean<KeycloakSessionServletFilter> keycloakSessionManagement(KeycloakCustomProperties customProperties) {
+    protected FilterRegistrationBean<UndertowRequestFilter> keycloakSessionManagement(KeycloakCustomProperties customProperties) {
 
-        FilterRegistrationBean<KeycloakSessionServletFilter> filter = new FilterRegistrationBean<>();
+        FilterRegistrationBean<UndertowRequestFilter> filter = new FilterRegistrationBean<>();
         filter.setName("Keycloak Session Management");
-        filter.setFilter(new KeycloakSessionServletFilter());
+        filter.setFilter(new UndertowRequestFilter());
         filter.addUrlPatterns(customProperties.getServer().getKeycloakPath() + "/*");
 
         return filter;

--- a/embedded-keycloak-server-spring-boot-support/src/main/java/com/github/thomasdarimont/keycloak/embedded/support/UndertowRequestFilter.java
+++ b/embedded-keycloak-server-spring-boot-support/src/main/java/com/github/thomasdarimont/keycloak/embedded/support/UndertowRequestFilter.java
@@ -1,0 +1,86 @@
+/*
+ * Copyright 2016 Red Hat, Inc. and/or its affiliates
+ * and other contributors as indicated by the @author tags.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.github.thomasdarimont.keycloak.embedded.support;
+
+import org.keycloak.common.ClientConnection;
+import org.keycloak.services.filters.AbstractRequestFilter;
+
+import javax.servlet.*;
+import javax.servlet.http.HttpServletRequest;
+import java.io.UnsupportedEncodingException;
+
+public class UndertowRequestFilter extends AbstractRequestFilter implements Filter {
+
+    @Override
+    public void doFilter(ServletRequest servletRequest, ServletResponse servletResponse, FilterChain filterChain)
+            throws UnsupportedEncodingException {
+        servletRequest.setCharacterEncoding("UTF-8");
+        final HttpServletRequest request = (HttpServletRequest) servletRequest;
+
+        filter(createClientConnection(request), (session) -> {
+            try {
+                filterChain.doFilter(servletRequest, servletResponse);
+            } catch (Exception e) {
+                throw new RuntimeException(e);
+            }
+        });
+    }
+
+    private ClientConnection createClientConnection(HttpServletRequest request) {
+        return new ClientConnection() {
+            @Override
+            public String getRemoteAddr() {
+                String forwardedFor = request.getHeader("X-Forwarded-For");
+
+                if (forwardedFor != null) {
+                    return forwardedFor;
+                }
+
+                return request.getRemoteAddr();
+            }
+
+            @Override
+            public String getRemoteHost() {
+                return request.getRemoteHost();
+            }
+
+            @Override
+            public int getRemotePort() {
+                return request.getRemotePort();
+            }
+
+            @Override
+            public String getLocalAddr() {
+                return request.getLocalAddr();
+            }
+
+            @Override
+            public int getLocalPort() {
+                return request.getLocalPort();
+            }
+        };
+    }
+
+    @Override
+    public void init(FilterConfig filterConfig) {
+    }
+
+    @Override
+    public void destroy() {
+    }
+}

--- a/pom.xml
+++ b/pom.xml
@@ -25,9 +25,9 @@
         <maven.compiler.target>${java.version}</maven.compiler.target>
         <maven.compiler.release>${java.version}</maven.compiler.release>
 
-        <keycloak.version>10.0.2</keycloak.version>
+        <keycloak.version>11.0.0</keycloak.version>
         <resteasy.version>3.11.2.Final</resteasy.version>
-        <infinispan.version>9.4.19.Final</infinispan.version>
+        <infinispan.version>10.1.8.Final</infinispan.version>
         <jgroups.version>4.2.4.Final</jgroups.version>
 
         <auto-service.version>1.0-rc6</auto-service.version>

--- a/readme.md
+++ b/readme.md
@@ -15,7 +15,7 @@ The following table shows the Keycloak versions used by the embedded Keycloak Se
 Embedded Keycloak Server | Keycloak
 ---|---
 1.x.y | 9.0.3
-2.x.y | 10.0.2
+2.x.y | 11.0.0
 
 ## Modules
 


### PR DESCRIPTION
Due to changes in Keycloak 11 there was also a need to add a Filter class for the undertow server. 
The class itself is the same as https://github.com/keycloak/keycloak/blob/master/testsuite/utils/src/main/java/org/keycloak/testsuite/UndertowRequestFilter.java