### PR TITLE
Fix Undertow dependency handling

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -56,11 +56,6 @@
 
         <dependency>
             <groupId>org.springframework.boot</groupId>
-            <artifactId>spring-boot-starter-undertow</artifactId>
-        </dependency>
-
-        <dependency>
-            <groupId>org.springframework.boot</groupId>
             <artifactId>spring-boot-starter-actuator</artifactId>
         </dependency>
 
@@ -284,6 +279,9 @@
             <build>
                 <finalName>${project.artifactId}-undertow-${project.version}</finalName>
             </build>
+            <activation>
+                <activeByDefault>true</activeByDefault>
+            </activation>
             <dependencies>
                 <dependency>
                     <groupId>org.springframework.boot</groupId>


### PR DESCRIPTION
Closes #27.

This doesn't seem to have broken the library - the `plain` application runs OK.