### PR TITLE
Replaced empty array with null when config-key absent

### DIFF
--- a/embedded-keycloak-server-spring-boot-support/src/main/java/com/github/thomasdarimont/keycloak/embedded/support/SpringBootConfigProvider.java
+++ b/embedded-keycloak-server-spring-boot-support/src/main/java/com/github/thomasdarimont/keycloak/embedded/support/SpringBootConfigProvider.java
@@ -86,7 +86,7 @@ public class SpringBootConfigProvider implements Config.ConfigProvider {
         public String[] getArray(String key) {
             Object obj = getObject(key, null);
             if (obj == null) {
-                return new String[0];
+                return null;
             }
 
             // TODO find better way to parse config yaml into a list instead of a LinkedHashMap in the first place


### PR DESCRIPTION
previously caused validating user-fields always as read-only
and prevented adding and updating users through console and rest-api.