### PR TITLE
Fix server-plain unit test

### DIFF
--- a/embedded-keycloak-server-plain/src/test/java/com/github/thomasdarimont/keycloak/EmbeddedSpringBootKeycloakServerXApplicationTests.java
+++ b/embedded-keycloak-server-plain/src/test/java/com/github/thomasdarimont/keycloak/EmbeddedSpringBootKeycloakServerXApplicationTests.java
@@ -2,8 +2,9 @@ package com.github.thomasdarimont.keycloak;
 
 import org.junit.jupiter.api.Test;
 import org.springframework.boot.test.context.SpringBootTest;
+import com.github.thomasdarimont.keycloak.embedded.runner.Main;
 
-@SpringBootTest(webEnvironment = SpringBootTest.WebEnvironment.DEFINED_PORT)
+@SpringBootTest(classes = Main.class, webEnvironment = SpringBootTest.WebEnvironment.DEFINED_PORT)
 class EmbeddedSpringBootKeycloakServerXApplicationTests {
 
     @Test


### PR DESCRIPTION
it is nice when `mvn test` is green for all subproject out of the box.