### PR TITLE
Support keycloak 20.0.3

### DIFF
--- a/embedded-keycloak-server-plain/src/main/resources/application.yml
+++ b/embedded-keycloak-server-plain/src/main/resources/application.yml
@@ -1,7 +1,7 @@
 spring:
   datasource:
     username: sa
-    url: jdbc:h2:./data/keycloak;DB_CLOSE_ON_EXIT=FALSE
+    url: jdbc:h2:./data/keycloak;DB_CLOSE_ON_EXIT=FALSE;NON_KEYWORDS=VALUE
     hikari:
       maximum-pool-size: 25
       minimum-idle: 1

--- a/embedded-keycloak-server-spring-boot-support/src/main/java/com/github/thomasdarimont/keycloak/embedded/EmbeddedKeycloakServer.java
+++ b/embedded-keycloak-server-spring-boot-support/src/main/java/com/github/thomasdarimont/keycloak/embedded/EmbeddedKeycloakServer.java
@@ -20,7 +20,7 @@ public class EmbeddedKeycloakServer {
 
         return (evt) -> {
 
-            log.infof("Using Keycloak Version: %s", Version.VERSION_KEYCLOAK);
+            log.infof("Using Keycloak Version: %s", Version.VERSION);
             log.infof("Enabled Keycloak Features (Deprecated): %s", Profile.getDeprecatedFeatures());
             log.infof("Enabled Keycloak Features (Preview): %s", Profile.getPreviewFeatures());
             log.infof("Enabled Keycloak Features (Experimental): %s", Profile.getExperimentalFeatures());

--- a/embedded-keycloak-server-spring-boot-support/src/main/java/com/github/thomasdarimont/keycloak/embedded/support/SpringBootPlatformProvider.java
+++ b/embedded-keycloak-server-spring-boot-support/src/main/java/com/github/thomasdarimont/keycloak/embedded/support/SpringBootPlatformProvider.java
@@ -2,6 +2,7 @@ package com.github.thomasdarimont.keycloak.embedded.support;
 
 import com.google.auto.service.AutoService;
 import lombok.extern.slf4j.Slf4j;
+import org.keycloak.Config;
 import org.keycloak.platform.PlatformProvider;
 import org.keycloak.services.ServicesLogger;
 import org.springframework.boot.context.event.ApplicationReadyEvent;
@@ -61,6 +62,11 @@ public class SpringBootPlatformProvider implements PlatformProvider, SmartApplic
     @Override
     public File getTmpDirectory() {
         return tmpDir;
+    }
+
+    @Override
+    public ClassLoader getScriptEngineClassLoader(Config.Scope scope) {
+        throw new UnsupportedOperationException();
     }
 
     protected void shutdown() {

--- a/pom.xml
+++ b/pom.xml
@@ -6,7 +6,7 @@
     <parent>
         <groupId>org.springframework.boot</groupId>
         <artifactId>spring-boot-starter-parent</artifactId>
-        <version>2.6.7</version>
+        <version>2.7.8</version>
         <relativePath/> <!-- lookup parent from repository -->
     </parent>
 
@@ -25,9 +25,9 @@
         <maven.compiler.target>${java.version}</maven.compiler.target>
         <maven.compiler.release>${java.version}</maven.compiler.release>
 
-        <keycloak.version>18.0.0</keycloak.version>
-        <resteasy.version>4.7.4.Final</resteasy.version>
-        <infinispan.version>13.0.8.Final</infinispan.version>
+        <keycloak.version>20.0.3</keycloak.version>
+        <resteasy.version>4.7.7.Final</resteasy.version>
+        <infinispan.version>13.0.10.Final</infinispan.version>
         <jgroups.version>4.2.20.Final</jgroups.version>
         <smallrye-metrics.version>3.0.3</smallrye-metrics.version>
         <liquibase.version>4.8.0</liquibase.version>
@@ -203,6 +203,36 @@
         <dependency>
             <groupId>org.keycloak</groupId>
             <artifactId>keycloak-model-jpa</artifactId>
+            <version>${keycloak.version}</version>
+        </dependency>
+
+        <dependency>
+            <groupId>org.keycloak</groupId>
+            <artifactId>keycloak-crypto-default</artifactId>
+            <version>${keycloak.version}</version>
+        </dependency>
+
+        <dependency>
+            <groupId>org.keycloak</groupId>
+            <artifactId>keycloak-admin-ui</artifactId>
+            <version>${keycloak.version}</version>
+        </dependency>
+
+        <dependency>
+            <groupId>org.keycloak</groupId>
+            <artifactId>keycloak-model-legacy</artifactId>
+            <version>${keycloak.version}</version>
+        </dependency>
+
+        <dependency>
+            <groupId>org.keycloak</groupId>
+            <artifactId>keycloak-model-legacy-private</artifactId>
+            <version>${keycloak.version}</version>
+        </dependency>
+
+        <dependency>
+            <groupId>org.keycloak</groupId>
+            <artifactId>keycloak-model-legacy-services</artifactId>
             <version>${keycloak.version}</version>
         </dependency>
 

--- a/readme.md
+++ b/readme.md
@@ -24,6 +24,8 @@ Embedded Keycloak Server | Keycloak | Spring Boot
 6.0.y | 16.1.1   | 2.5.10
 7.0.y | 17.0.1   | 2.6.7
 8.0.y | 18.0.0   | 2.6.7
+9.0.y | unsupported
+10.0.y | 20.0.0  | 2.7.8
 
 ## Modules
 


### PR DESCRIPTION
https://github.com/thomasdarimont/embedded-spring-boot-keycloak-server/issues/74

bump spring boot to `2.7.8`
versions of transitive dependencies match to [maven central](https://mvnrepository.com/artifact/org.keycloak/keycloak-dependencies-server-all/20.0.3)